### PR TITLE
Refactor/22

### DIFF
--- a/InstaBotPrototype/DBMigrator/App.config
+++ b/InstaBotPrototype/DBMigrator/App.config
@@ -4,6 +4,6 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
   <connectionStrings>
-    <add name="TestDB" connectionString="Data Source=HACKERPC;Initial Catalog=TestDB;Integrated Security=True;Pooling=False" providerName="System.Data.SqlClient" />
+    <add name="TestDB" connectionString="Data Source=.;Initial Catalog=TestDB;Integrated Security=True;Pooling=False" providerName="System.Data.SqlClient" />
   </connectionStrings>
 </configuration>

--- a/InstaBotPrototype/DBMigrator/DBMigration.cs
+++ b/InstaBotPrototype/DBMigrator/DBMigration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data.Common;
+using static System.Console;
 
 namespace DBMigrator
 {
@@ -27,7 +28,13 @@ namespace DBMigrator
                 }
 
             }
-            catch { }
+            catch
+            {
+                WriteLine("Error happened");
+                WriteLine("Try restarting this application");
+                WriteLine("If you continue getting this message, connect application distributor");
+                WriteLine(string.Empty.PadRight(WindowWidth - 1, '-'));
+            }
         }
 
         public DbCommand ApplyCommand { get; private set; }

--- a/InstaBotPrototype/DBMigrator/DBMigration.cs
+++ b/InstaBotPrototype/DBMigrator/DBMigration.cs
@@ -1,65 +1,43 @@
-﻿using System;
-using System.Data.Common;
+﻿using System.Data.Common;
 
 namespace DBMigrator
 {
-    internal class DBMigration
+    abstract class DBMigration
     {
-        #region Public Constructors
-
-        public DBMigration(DbCommand applyCommand, DbCommand reverseCommand, string name)
+        public DBMigration(DbProviderFactory factory, DbConnection connection)
         {
-            ApplyCommand = applyCommand;
-            ReverseCommand = reverseCommand;
-            Name = name;
+            Factory = factory;
+
+            Name = GetType().Name;
+
+            ApplyCommand = Factory.CreateCommand();
+            ReverseCommand = Factory.CreateCommand();
+
+            this.connection = connection;
         }
-
-        #endregion Public Constructors
-
-        #region Public Properties
 
         public DbCommand ApplyCommand { get; private set; }
-        public string ConnectionString { get; set; }
-        public DbProviderFactory Factory { get; set; }
-        public bool IsApplied { get; set; }
-        public string Name { get; private set; }
         public DbCommand ReverseCommand { get; private set; }
+        public DbProviderFactory Factory { get; set; }
+        public string Name { get; private set; }
+        public bool IsApplied { get; set; }
+        DbConnection connection;
 
-        #endregion Public Properties
-
-        #region Public Methods
-
-        public bool Apply()
+        public void Apply()
         {
-            IsApplied = Run(ApplyCommand);
-
-            if (IsApplied)
-            {
-                AddLog();
-            }
-
-            return IsApplied;
+            Run(ApplyCommand);
+            AddLog();
         }
 
-        public bool Reverse()
+        public void Reverse()
         {
-            IsApplied = !Run(ReverseCommand);
-
-            if (!IsApplied)
-            {
-                RemoveLog();
-            }
-
-            return IsApplied;
+            Run(ReverseCommand);
+            RemoveLog();
         }
-
-        #endregion Public Methods
-
-        #region Private Methods
 
         private void AddLog()
         {
-            DbCommand command = Factory.CreateCommand();
+            var command = Factory.CreateCommand();
             command.CommandText = $"INSERT INTO dbo.Migrations (Name, ApplyTime) VALUES ('{Name}', GetDate())";
 
             Run(command);
@@ -67,36 +45,15 @@ namespace DBMigrator
 
         private void RemoveLog()
         {
-            DbCommand command = Factory.CreateCommand();
+            var command = Factory.CreateCommand();
             command.CommandText = $"delete from dbo.Migrations where Name='{Name}'";
 
             Run(command);
         }
 
-        private bool Run(DbCommand command)
+        private void Run(DbCommand command)
         {
-            bool correct = true;
-            DbConnection dbConnection = Factory.CreateConnection();
-            dbConnection.ConnectionString = ConnectionString;
-
-            command.Connection = dbConnection;
-
-            try
-            {
-                dbConnection.Open();
-                command.ExecuteNonQuery();
-            }
-            catch
-            {
-                correct = false;
-            }
-            finally
-            {
-                dbConnection?.Close();
-            }
-            return correct;
-        }
-
-        #endregion Private Methods
+            command.Connection = connection;
+            command.ExecuteNonQuery(); }
     }
 }

--- a/InstaBotPrototype/DBMigrator/DBMigration.cs
+++ b/InstaBotPrototype/DBMigrator/DBMigration.cs
@@ -28,9 +28,9 @@ namespace DBMigrator
                 }
 
             }
-            catch
+            catch(Exception e)
             {
-                WriteLine("Error happened");
+                WriteLine("Error happened {0}",e.Message);
                 WriteLine("Try restarting this application");
                 WriteLine("If you continue getting this message, connect application distributor");
                 WriteLine(string.Empty.PadRight(WindowWidth - 1, '-'));

--- a/InstaBotPrototype/DBMigrator/DBMigration.cs
+++ b/InstaBotPrototype/DBMigrator/DBMigration.cs
@@ -14,13 +14,27 @@ namespace DBMigrator
             ReverseCommand = Factory.CreateCommand();
 
             this.connection = connection;
+
+            var command = factory.CreateCommand();
+            command.CommandText = $"select count(*) from dbo.Migrations where Name = '{Name}'";
+            command.Connection = connection;
+
+            try
+            {
+                if ((int)command.ExecuteScalar() == 1)
+                {
+                    IsApplied = true;
+                }
+
+            }
+            catch { }
         }
 
         public DbCommand ApplyCommand { get; private set; }
         public DbCommand ReverseCommand { get; private set; }
-        public DbProviderFactory Factory { get; set; }
+        public DbProviderFactory Factory { get; private set; }
         public string Name { get; private set; }
-        public bool IsApplied { get; set; }
+        public bool IsApplied { get; private set; }
         DbConnection connection;
 
         public void Apply()

--- a/InstaBotPrototype/DBMigrator/DBMigrator.csproj
+++ b/InstaBotPrototype/DBMigrator/DBMigrator.csproj
@@ -43,7 +43,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Migrations\CreateMigrationsTable.cs" />
+    <Compile Include="Migrations\CreateUsersTable.cs" />
     <Compile Include="DBMigration.cs" />
+    <Compile Include="IndexerAttribute.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/InstaBotPrototype/DBMigrator/IndexerAttribute.cs
+++ b/InstaBotPrototype/DBMigrator/IndexerAttribute.cs
@@ -4,7 +4,7 @@ namespace DBMigrator
 {
     class IndexerAttribute : Attribute
     {
-        public int Id { get; set; }
-        public IndexerAttribute(int id) => Id = id;
+        public long Id { get; private set; }
+        public IndexerAttribute(long id) => Id = id;
     }
 }

--- a/InstaBotPrototype/DBMigrator/IndexerAttribute.cs
+++ b/InstaBotPrototype/DBMigrator/IndexerAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace DBMigrator
+{
+    class IndexerAttribute : Attribute
+    {
+        public int Id { get; set; }
+        public IndexerAttribute(int id) => Id = id;
+    }
+}

--- a/InstaBotPrototype/DBMigrator/Migrations/CreateMigrationsTable.cs
+++ b/InstaBotPrototype/DBMigrator/Migrations/CreateMigrationsTable.cs
@@ -1,0 +1,14 @@
+﻿using System.Data.Common;
+
+namespace DBMigrator
+{
+    [Indexer(0)]
+    class CreateMigrationsTable : DBMigration
+    {
+        public CreateMigrationsTable(object factory, object connection) : base(factory as DbProviderFactory, connection as DbConnection)
+        {
+            ApplyCommand.CommandText = "create table dbo.Migrations (Name nvarchar(100), ApplyTime DateTime)";
+            ReverseCommand.CommandText = "drop table dbo.Migrations";
+        }
+    }
+}

--- a/InstaBotPrototype/DBMigrator/Migrations/CreateMigrationsTable.cs
+++ b/InstaBotPrototype/DBMigrator/Migrations/CreateMigrationsTable.cs
@@ -2,13 +2,13 @@
 
 namespace DBMigrator
 {
-    [Indexer(0)]
-    class CreateMigrationsTable : DBMigration
+    [Indexer(0)] // Apply attribute (index must be greater than indexes used before)
+    class CreateMigrationsTable : DBMigration // Derive from base class
     {
-        public CreateMigrationsTable(object factory, object connection) : base(factory as DbProviderFactory, connection as DbConnection)
+        public CreateMigrationsTable(object factory, object connection) : base(factory as DbProviderFactory, connection as DbConnection) // Call base constructor
         {
-            ApplyCommand.CommandText = "create table dbo.Migrations (Name nvarchar(100), ApplyTime DateTime)";
-            ReverseCommand.CommandText = "drop table dbo.Migrations";
+            ApplyCommand.CommandText = "create table dbo.Migrations (Name nvarchar(100), ApplyTime DateTime)"; // Hardcode database apply ...
+            ReverseCommand.CommandText = "drop table dbo.Migrations"; // ... and reverse commands
         }
-    }
+    } // Well done!
 }

--- a/InstaBotPrototype/DBMigrator/Migrations/CreateMigrationsTable.cs
+++ b/InstaBotPrototype/DBMigrator/Migrations/CreateMigrationsTable.cs
@@ -2,7 +2,7 @@
 
 namespace DBMigrator
 {
-    [Indexer(0)] // Apply attribute (index must be greater than indexes used before)
+    [Indexer(201711290739)] // Apply attribute (index must apply format yyyymmddhhmm)
     class CreateMigrationsTable : DBMigration // Derive from base class
     {
         public CreateMigrationsTable(object factory, object connection) : base(factory as DbProviderFactory, connection as DbConnection) // Call base constructor

--- a/InstaBotPrototype/DBMigrator/Migrations/CreateUsersTable.cs
+++ b/InstaBotPrototype/DBMigrator/Migrations/CreateUsersTable.cs
@@ -1,0 +1,14 @@
+﻿using System.Data.Common;
+
+namespace DBMigrator
+{
+    [Indexer(1)]
+    class CreateUsersTable : DBMigration
+    {
+        public CreateUsersTable(object factory, object connection) : base(factory as DbProviderFactory, connection as DbConnection)
+        {
+            ApplyCommand.CommandText = "create table dbo.Users (Id integer, Login nvarchar(100), Password nvarchar(100), primary key(Id))";
+            ReverseCommand.CommandText = "drop table dbo.Users";
+        }
+    }
+}

--- a/InstaBotPrototype/DBMigrator/Migrations/CreateUsersTable.cs
+++ b/InstaBotPrototype/DBMigrator/Migrations/CreateUsersTable.cs
@@ -7,7 +7,7 @@ namespace DBMigrator
     {
         public CreateUsersTable(object factory, object connection) : base(factory as DbProviderFactory, connection as DbConnection)
         {
-            ApplyCommand.CommandText = "create table dbo.Users (Id integer, Login nvarchar(100), Password nvarchar(100), primary key(Id))";
+            ApplyCommand.CommandText = "create table dbo.Users (Id int identity, Login nvarchar(100), Password nvarchar(100), primary key(Id))";
             ReverseCommand.CommandText = "drop table dbo.Users";
         }
     }

--- a/InstaBotPrototype/DBMigrator/Migrations/CreateUsersTable.cs
+++ b/InstaBotPrototype/DBMigrator/Migrations/CreateUsersTable.cs
@@ -2,7 +2,7 @@
 
 namespace DBMigrator
 {
-    [Indexer(1)]
+    [Indexer(201711290745)]
     class CreateUsersTable : DBMigration
     {
         public CreateUsersTable(object factory, object connection) : base(factory as DbProviderFactory, connection as DbConnection)

--- a/InstaBotPrototype/DBMigrator/Program.cs
+++ b/InstaBotPrototype/DBMigrator/Program.cs
@@ -1,93 +1,44 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Configuration;
 using System.Data.Common;
-using System.IO;
+using System.Linq;
+using System.Reflection;
 
 namespace DBMigrator
 {
     internal class Program
     {
-        #region Private Methods
-
-        private static void ApplyMigrations(params DBMigration[] migrations)
+        private static void Main()
         {
-            for (int i = 0; i < migrations.Length; i++)
-            {
-                DBMigration migration = migrations[i];
-                if (migration.IsApplied)
-                {
-                    Console.WriteLine($"Migration {migration.Name} was applied");
-                }
-                else
-                {
-                    Console.WriteLine($"Migration {migration.Name} wasn't applied");
-                    Console.WriteLine("Applying...");
-
-                    if (migration.Apply())
-                    {
-                        Console.WriteLine($"Migration {migration.Name} is applied");
-                    }
-                    else
-                    {
-                        Console.WriteLine("Something went wrong...");
-                    }
-                }
-
-                Console.WriteLine(string.Empty.PadRight(30, '-'));
-            }
-        }
-
-        private static DBMigration[] GetMigrations()
-        {
-            List<DBMigration> list = new List<DBMigration>();
-
             string connString = ConfigurationManager.ConnectionStrings[1].ConnectionString;
             string provider = ConfigurationManager.ConnectionStrings[1].ProviderName;
 
-            DbProviderFactory factory = DbProviderFactories.GetFactory(provider);
+            var factory = DbProviderFactories.GetFactory(provider);
 
-            DbConnection dbConnection = factory.CreateConnection();
+            var dbConnection = factory.CreateConnection();
             dbConnection.ConnectionString = connString;
 
-            DirectoryInfo directory = new DirectoryInfo(Directory.GetCurrentDirectory() + "/Migrations");
 
-            foreach (FileInfo file in directory.GetFiles("*.txt"))
-            {
-                using (StreamReader streamReader = new StreamReader(file.OpenRead()))
-                {
-                    DbCommand apply = factory.CreateCommand();
-                    apply.CommandText = streamReader.ReadLine();
 
-                    DbCommand reverse = factory.CreateCommand();
-                    reverse.CommandText = streamReader.ReadLine();
+            var migrations = (from type in Assembly.GetCallingAssembly().GetTypes() where type.IsSubclassOf(typeof(DBMigration)) orderby type.GetCustomAttribute<IndexerAttribute>().Id select Activator.CreateInstance(type, new object[] { factory, dbConnection }) as DBMigration).ToList();
 
-                    string name = file.Name.Substring(0, file.Name.Length - 4);
 
-                    DBMigration migration = new DBMigration(apply, reverse, name) { Factory = factory, ConnectionString = connString };
 
-                    list.Add(migration);
-                }
-            }
-
-            dbConnection.Close();
-
-            DbCommand command = factory.CreateCommand();
+            var command = factory.CreateCommand();
             command.CommandText = "select * from dbo.Migrations";
-            command.Connection = factory.CreateConnection();
-            command.Connection.ConnectionString = connString;
+            command.Connection = dbConnection;
 
-            command.Connection.Open();
+            dbConnection.Open();
 
             try
             {
-                DbDataReader reader = command.ExecuteReader();
+                var reader = command.ExecuteReader();
 
                 while (reader.Read())
                 {
                     string name = (string)reader.GetValue(0);
 
-                    foreach (DBMigration migration in list)
+                    foreach (var migration in migrations)
                     {
                         if (migration.Name == name)
                         {
@@ -97,23 +48,31 @@ namespace DBMigrator
                     }
                 }
             }
-            catch
+            catch { }
+
+
+
+            foreach (var migration in migrations)
             {
+                int id = migration.GetType().GetCustomAttribute<IndexerAttribute>().Id;
+                if (migration.IsApplied)
+                {
+                    Console.WriteLine($"Migration #{id} {migration.Name} was applied");
+                }
+                else
+                {
+                    Console.WriteLine($"Migration #{id} {migration.Name} wasn't applied");
+                    Console.WriteLine("Applying...");
+
+                    migration.Apply();
+
+                    Console.WriteLine($"Migration #{id} {migration.Name} is applied");
+                }
+
+                Console.WriteLine(string.Empty.PadRight(Console.WindowWidth - 1, '-'));
             }
-            finally
-            {
-                command?.Connection?.Close();
-            }
 
-            return list.ToArray();
+            dbConnection.Close();
         }
-
-        private static void Main(string[] args)
-        {
-            DBMigration[] migrations = GetMigrations();
-            ApplyMigrations(migrations);
-        }
-
-        #endregion Private Methods
     }
 }

--- a/InstaBotPrototype/DBMigrator/Program.cs
+++ b/InstaBotPrototype/DBMigrator/Program.cs
@@ -17,12 +17,10 @@ namespace DBMigrator
 
             var dbConnection = factory.CreateConnection();
             dbConnection.ConnectionString = connString;
-
-
+            
 
             var migrations = (from type in Assembly.GetCallingAssembly().GetTypes() where type.IsSubclassOf(typeof(DBMigration)) orderby type.GetCustomAttribute<IndexerAttribute>().Id select Activator.CreateInstance(type, new object[] { factory, dbConnection }) as DBMigration).ToList();
-
-
+            
 
             var command = factory.CreateCommand();
             command.CommandText = "select * from dbo.Migrations";
@@ -51,22 +49,21 @@ namespace DBMigrator
             catch { }
 
 
-
             foreach (var migration in migrations)
             {
-                int id = migration.GetType().GetCustomAttribute<IndexerAttribute>().Id;
+                long id = migration.GetType().GetCustomAttribute<IndexerAttribute>().Id;
                 if (migration.IsApplied)
                 {
-                    Console.WriteLine($"Migration #{id} {migration.Name} was applied");
+                    Console.WriteLine($"Migration {id} {migration.Name} was applied");
                 }
                 else
                 {
-                    Console.WriteLine($"Migration #{id} {migration.Name} wasn't applied");
+                    Console.WriteLine($"Migration {id} {migration.Name} wasn't applied");
                     Console.WriteLine("Applying...");
 
                     migration.Apply();
 
-                    Console.WriteLine($"Migration #{id} {migration.Name} is applied");
+                    Console.WriteLine($"Migration {id} {migration.Name} is applied");
                 }
 
                 Console.WriteLine(string.Empty.PadRight(Console.WindowWidth - 1, '-'));

--- a/InstaBotPrototype/DBMigrator/Program.cs
+++ b/InstaBotPrototype/DBMigrator/Program.cs
@@ -18,36 +18,9 @@ namespace DBMigrator
             var dbConnection = factory.CreateConnection();
             dbConnection.ConnectionString = connString;
             
-
-            var migrations = (from type in Assembly.GetCallingAssembly().GetTypes() where type.IsSubclassOf(typeof(DBMigration)) orderby type.GetCustomAttribute<IndexerAttribute>().Id select Activator.CreateInstance(type, new object[] { factory, dbConnection }) as DBMigration).ToList();
-            
-
-            var command = factory.CreateCommand();
-            command.CommandText = "select * from dbo.Migrations";
-            command.Connection = dbConnection;
-
             dbConnection.Open();
 
-            try
-            {
-                var reader = command.ExecuteReader();
-
-                while (reader.Read())
-                {
-                    string name = (string)reader.GetValue(0);
-
-                    foreach (var migration in migrations)
-                    {
-                        if (migration.Name == name)
-                        {
-                            migration.IsApplied = true;
-                            break;
-                        }
-                    }
-                }
-            }
-            catch { }
-
+            var migrations = (from type in Assembly.GetCallingAssembly().GetTypes() where type.IsSubclassOf(typeof(DBMigration)) orderby type.GetCustomAttribute<IndexerAttribute>().Id select Activator.CreateInstance(type, new object[] { factory, dbConnection }) as DBMigration).ToList();
 
             foreach (var migration in migrations)
             {


### PR DESCRIPTION
Changed the way it works to reflection and derived types.
Now to create new migration you have to derive class from DBMigration, make custom constructor and adorn this class with custom attribute as follows:

    [Indexer(201711290739)] // Apply attribute (index must apply format yyyymmddhhmm)
    class CreateMigrationsTable : DBMigration // Derive from base class
    {
        public CreateMigrationsTable(object factory, object connection) : base(factory as DbProviderFactory, connection as DbConnection) // Call base constructor
        {
            ApplyCommand.CommandText = "create table dbo.Migrations (Name nvarchar(100), ApplyTime DateTime)"; // Hardcode database apply ...
            ReverseCommand.CommandText = "drop table dbo.Migrations"; // ... and reverse commands
        }
    } // Well done!